### PR TITLE
pathlib code can be shorter

### DIFF
--- a/birdwatcher/videoinput.py
+++ b/birdwatcher/videoinput.py
@@ -43,13 +43,12 @@ class VideoFile():
         return d
     
     def derive_filepath(self, s, suffix=None, path=None):
-        parts = list(self.filepath.parts)
         stem = self.filepath.stem
         if suffix is None:
             suffix = self.filepath.suffix
         filename = f'{stem}_{s}{suffix}'
         if path is None:
-            dpath =  pathlib.Path('/'.join(parts[:-1] + [filename]))
+            dpath =  self.filepath.parent / filename
         else:
             dpath = pathlib.Path(path) / filename
         return dpath


### PR DESCRIPTION
I have made a small change in videoinput using pathlib functionality. This makes the code shorter and easier to read.

I think there might be some others lines of code where pathlib can be used more efficiently to make the code shorter and easier to read. I could check this and add those changes to this Pull Request as well.