### PR TITLE
Tests for archive coordinate arrays 

### DIFF
--- a/birdwatcher/coordinatearrays.py
+++ b/birdwatcher/coordinatearrays.py
@@ -31,6 +31,11 @@ __all__ = ['CoordinateArrays', 'create_coordarray',
            'delete_coordinatearray', 'move_coordinatearrays']
 
 
+def _archive(rar):
+    rar.archive(overwrite=True)
+    delete_raggedarray(rar)
+
+
 def _coordstoframe(coords, width, height, nchannels=None, dtype='uint8',
                    value=1):
     if nchannels is None:
@@ -374,8 +379,6 @@ def extract_archivedcoordinatedata(path):
     
     while path.suffix in {'.tar', '.xz'}: # remove extensions
         path = path.with_suffix('')
-        
-    print(path)
 
     return CoordinateArrays(path)
 

--- a/birdwatcher/movementdetection/movementdetection.py
+++ b/birdwatcher/movementdetection/movementdetection.py
@@ -5,6 +5,7 @@ import darr
 
 import birdwatcher as bw
 from birdwatcher.utils import derive_filepath
+from birdwatcher.coordinatearrays import _archive
 
 
 __all__ = ['batch_detect_movement', 'detect_movement', 'apply_settings', 
@@ -15,11 +16,6 @@ default_settings = {'processing':{'color': False, # booleans only
                                   'blur': 0, # use '0' for no blur
                                   'morphologyex': True, # booleans only
                                   'resizebyfactor': 1}} # use '1' for no change in size
-
-
-def _archive(rar):
-    rar.archive(overwrite=True)
-    darr.delete_raggedarray(rar)
 
 
 def batch_detect_movement(vfs_list, settings=None, startat=None, 

--- a/birdwatcher/movementdetection/movementdetection.py
+++ b/birdwatcher/movementdetection/movementdetection.py
@@ -17,7 +17,7 @@ default_settings = {'processing':{'color': False, # booleans only
                                   'resizebyfactor': 1}} # use '1' for no change in size
 
 
-def _f(rar):
+def _archive(rar):
     rar.archive(overwrite=True)
     darr.delete_raggedarray(rar)
 
@@ -63,7 +63,7 @@ def batch_detect_movement(vfs_list, settings=None, startat=None,
             tobearchived.append(cd)
             if (len(tobearchived) == nprocesses) or (i == (len(vfs_list)-1)):
                 with ThreadPool(processes=nprocesses) as pool:
-                    list([i for i in pool.imap_unordered(_f, tobearchived)])
+                    list([i for i in pool.imap_unordered(_archive, tobearchived)])
                 tobearchived = []
 
 

--- a/birdwatcher/tests/test_coordinatearrays.py
+++ b/birdwatcher/tests/test_coordinatearrays.py
@@ -91,6 +91,12 @@ class TestArchivedCoordinateArrays(unittest.TestCase):
         with bw.open_archivedcoordinatedata(self.archivename) as ca2:
             assert_array_equal(ca2[1], coords1)
 
+    def test_extract_archived(self):
+        coords1 = self.ca1[1]
+        _archive(self.ca1)
+        ca2 = bw.extract_archivedcoordinatedata(self.archivename)
+        assert_array_equal(ca2[1], coords1)
+
 
 class TestMoveCoordinateArrays(unittest.TestCase):
 

--- a/birdwatcher/tests/test_movementdetection.py
+++ b/birdwatcher/tests/test_movementdetection.py
@@ -38,9 +38,7 @@ class TestDetectMovement(unittest.TestCase):
 
     def setUp(self):
         self.tempdirname1 = Path(tempfile.mkdtemp())
-        self.vfs = (bw.testvideosmall()
-                      .iter_frames(nframes=200)
-                      .tovideo(self.tempdirname1 / 'even1.mp4', framerate=25))
+        self.vfs = bw.testvideosmall()
 
     def tearDown(self):
         shutil.rmtree(self.tempdirname1)
@@ -68,29 +66,26 @@ class TestBatchDetectMovement(unittest.TestCase):
 
     def setUp(self):
         self.tempdirname1 = Path(tempfile.mkdtemp())
-        self.vfs = (bw.testvideosmall()
+        self.vfs1 = (bw.testvideosmall()
                     .iter_frames(nframes=200)
-                    .tovideo(self.tempdirname1 / 'even1.mp4', framerate=25))
+                    .tovideo(self.tempdirname1 / 'video1.mp4', framerate=25))
+        self.vfs2 = (bw.testvideosmall()
+                    .iter_frames(nframes=200)
+                    .tovideo(self.tempdirname1 / 'video2.mp4', framerate=25))
 
     def tearDown(self):
          shutil.rmtree(self.tempdirname1)
 
     def test_batchdetection(self):
-        p1 = self.vfs
-        p2 = p1.iter_frames().tovideo(self.tempdirname1 / 'even2.mp4',
-                                      framerate=p1.avgframerate)
-        md.batch_detect_movement([p1,p2], nframes=200,
+        md.batch_detect_movement([self.vfs1,self.vfs2], nframes=200,
                                  analysispath=self.tempdirname1, 
                                  overwrite=True, archived=False)
-        filepath = self.tempdirname1 / 'movement_even1/coords.darr'
-        self.assertTrue(Path.exists(filepath))
-        
+        self.assertTrue(Path.exists(self.tempdirname1/'movement_video1/coords.darr'))
+        self.assertTrue(Path.exists(self.tempdirname1/'movement_video2/coords.darr'))
+
     def test_batcharchive(self):
-        p1 = self.vfs
-        p2 = p1.iter_frames().tovideo(self.tempdirname1 / 'even2.mp4',
-                                      framerate=p1.avgframerate)
-        md.batch_detect_movement([p1,p2], nframes=200,
+        md.batch_detect_movement([self.vfs1,self.vfs2], nframes=200,
                                  analysispath=self.tempdirname1,
                                  overwrite=True, archived=True)
-        filepath = self.tempdirname1 / 'movement_even1/coords.darr.tar.xz'
-        self.assertTrue(Path.exists(filepath))
+        self.assertTrue(Path.exists(self.tempdirname1/'movement_video1/coords.darr.tar.xz'))
+        self.assertTrue(Path.exists(self.tempdirname1/'movement_video2/coords.darr.tar.xz'))


### PR DESCRIPTION
Currently, the only way in which coordinatearrays are archived in birdwatcher, is by using the batch_detect_movement function, which uses the 'privat' _archive function (previously _f, but I changed the name). In _archive 2 darr functions are used to (1) archive the coordinatearrays with its own folder name and (2) the original darr array is removed. 

- I've written a test for the _archive function to check these two functionalities (in case darr changes someday)
- I've changed the test for open_archivedcoordinatedata, which uses the _archive function now
- I've added a test for extract_archivedcoordinatedata