### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/gbeckers/Birdwatcher/security/code-scanning/2](https://github.com/gbeckers/Birdwatcher/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so every job inherits least-privilege token scopes.  
Best fix here: define at workflow root (top-level), since there is one job and no special write scopes are shown in this snippet.

For `.github/workflows/python_package.yml`, insert:

- `permissions:`
  - `contents: read`

Place it after the `on:` block (or before `jobs:`), so it applies globally.  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
